### PR TITLE
Configure FileStreamOptions with PreallocationSize and async access in ZipArchiveEntry extract methods

### DIFF
--- a/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchiveEntry.Extract.Async.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchiveEntry.Extract.Async.cs
@@ -71,7 +71,7 @@ public static partial class ZipFileExtensions
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        ExtractToFileInitialize(source, destinationFileName, overwrite, out FileStreamOptions fileStreamOptions);
+        ExtractToFileInitialize(source, destinationFileName, overwrite, async: true, out FileStreamOptions fileStreamOptions);
 
         FileStream fs = new FileStream(destinationFileName, fileStreamOptions);
         await using (fs)

--- a/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchiveEntry.Extract.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchiveEntry.Extract.cs
@@ -62,7 +62,7 @@ namespace System.IO.Compression
         /// <param name="overwrite">True to indicate overwrite.</param>
         public static void ExtractToFile(this ZipArchiveEntry source, string destinationFileName, bool overwrite)
         {
-            ExtractToFileInitialize(source, destinationFileName, overwrite, out FileStreamOptions fileStreamOptions);
+            ExtractToFileInitialize(source, destinationFileName, overwrite, async: false, out FileStreamOptions fileStreamOptions);
 
             using (FileStream fs = new FileStream(destinationFileName, fileStreamOptions))
             {
@@ -73,7 +73,7 @@ namespace System.IO.Compression
             ExtractToFileFinalize(source, destinationFileName);
         }
 
-        private static void ExtractToFileInitialize(ZipArchiveEntry source, string destinationFileName, bool overwrite, out FileStreamOptions fileStreamOptions)
+        private static void ExtractToFileInitialize(ZipArchiveEntry source, string destinationFileName, bool overwrite, bool async, out FileStreamOptions fileStreamOptions)
         {
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(destinationFileName);
@@ -83,7 +83,9 @@ namespace System.IO.Compression
                 Access = FileAccess.Write,
                 Mode = overwrite ? FileMode.Create : FileMode.CreateNew,
                 Share = FileShare.None,
-                BufferSize = ZipFile.FileStreamBufferSize
+                BufferSize = ZipFile.FileStreamBufferSize,
+                PreallocationSize = source.Length,
+                Options = async ? FileOptions.Asynchronous : FileOptions.None
             };
 
             const UnixFileMode OwnershipPermissions =


### PR DESCRIPTION
Set \PreallocationSize\ on \FileStreamOptions\ based on the entry's uncompressed size (\ZipArchiveEntry.Length\) to allow the file system to pre-allocate disk space, reducing fragmentation and improving write performance.

Configure \FileOptions.Asynchronous\ when extracting from async methods (\ExtractToFileAsync\) so the \FileStream\ uses async I/O.

### Changes

- Added \PreallocationSize = source.Length\ to \FileStreamOptions\ in \ExtractToFileInitialize\.
- Added \ool async\ parameter to \ExtractToFileInitialize\ that sets \FileOptions.Asynchronous\ when \	rue\.
- Sync callers pass \sync: false\, async callers pass \sync: true\.