### PR TITLE
Validate base64 in NegotiateAuthentication.GetOutgoingBlob(string)

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/Security/NegotiateAuthentication.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/NegotiateAuthentication.cs
@@ -253,12 +253,27 @@ namespace System.Net.Security
         /// </remarks>
         public string? GetOutgoingBlob(string? incomingBlob, out NegotiateAuthenticationStatusCode statusCode)
         {
-            byte[]? decodedIncomingBlob = null;
+            byte[]? rentedBuffer = null;
+            ReadOnlySpan<byte> decodedIncomingBlob = default;
             if (!string.IsNullOrEmpty(incomingBlob))
             {
-                decodedIncomingBlob = Convert.FromBase64String(incomingBlob);
+                rentedBuffer = ArrayPool<byte>.Shared.Rent((incomingBlob.Length / 4) * 3);
+                if (!Convert.TryFromBase64String(incomingBlob, rentedBuffer, out int decodedLength))
+                {
+                    ArrayPool<byte>.Shared.Return(rentedBuffer);
+                    statusCode = NegotiateAuthenticationStatusCode.InvalidToken;
+                    return null;
+                }
+
+                decodedIncomingBlob = rentedBuffer.AsSpan(0, decodedLength);
             }
+
             byte[]? decodedOutgoingBlob = GetOutgoingBlob(decodedIncomingBlob, out statusCode);
+
+            if (rentedBuffer is not null)
+            {
+                ArrayPool<byte>.Shared.Return(rentedBuffer);
+            }
 
             string? outgoingBlob = null;
             if (decodedOutgoingBlob != null && decodedOutgoingBlob.Length > 0)

--- a/src/libraries/System.Net.Security/tests/UnitTests/NegotiateAuthenticationTests.cs
+++ b/src/libraries/System.Net.Security/tests/UnitTests/NegotiateAuthenticationTests.cs
@@ -85,6 +85,20 @@ namespace System.Net.Security.Tests
             Assert.Equal(NegotiateAuthenticationStatusCode.Unsupported, statusCode);
         }
 
+        [Theory]
+        [InlineData("!!!!")]
+        [InlineData("AAA")]
+        [InlineData("AAAAA")]
+        [InlineData("AA=A")]
+        public void GetOutgoingBlob_InvalidBase64_ReturnsInvalidToken(string incomingBlob)
+        {
+            NegotiateAuthenticationClientOptions clientOptions = new NegotiateAuthenticationClientOptions { Package = "Negotiate", Credential = s_testCredentialRight, TargetName = "HTTP/foo" };
+            NegotiateAuthentication negotiateAuthentication = new NegotiateAuthentication(clientOptions);
+            string? outgoingBlob = negotiateAuthentication.GetOutgoingBlob(incomingBlob, out NegotiateAuthenticationStatusCode statusCode);
+            Assert.Null(outgoingBlob);
+            Assert.Equal(NegotiateAuthenticationStatusCode.InvalidToken, statusCode);
+        }
+
         [ConditionalFact(typeof(NegotiateAuthenticationTests), nameof(IsNtlmAvailable))]
         public void Package_Supported_NTLM()
         {


### PR DESCRIPTION
The `string`-based `NegotiateAuthentication.GetOutgoingBlob` overload decoded the incoming blob with `Convert.FromBase64String`, which throws `FormatException` on malformed input. Callers that hand-off untrusted client tokens (e.g. HTTP servers parsing `Authorization: Negotiate <blob>`) had no way to get the documented `InvalidToken` status code for that case without wrapping the call in a try/catch.

This change switches to `Convert.TryFromBase64String` and returns `NegotiateAuthenticationStatusCode.InvalidToken` with a `null` outgoing blob when decoding fails, matching the contract on the other failure paths. The decode buffer is rented from `ArrayPool<byte>` and sliced to the actual decoded length, then passed to the existing `ReadOnlySpan<byte>` overload so we avoid both the throw and the extra allocation on the happy path.

Tests cover a few representative malformed inputs (non-base64 characters, wrong length, misplaced padding).